### PR TITLE
quick fix for making it work on Gutenberg

### DIFF
--- a/admin/class-plugin-edit.php
+++ b/admin/class-plugin-edit.php
@@ -73,13 +73,13 @@ final class PDEV_Plugin_Edit {
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue' ) );
 
 		// Output the plugin details box.
-		add_action( 'edit_form_after_editor', array( $this, 'plugin_details_box' ) );
+		//add_action( 'edit_form_after_editor', array( $this, 'plugin_details_box' ) );
 
 		// Add/Remove meta boxes.
 		add_action( 'add_meta_boxes', array( $this, 'add_meta_boxes' ) );
 
 		// Add custom option to the publish/submit meta box.
-		add_action( 'post_submitbox_misc_actions', array( $this, 'submitbox_misc_actions' ) );
+		//add_action( 'post_submitbox_misc_actions', array( $this, 'submitbox_misc_actions' ) );
 
 		// Save metadata on post save.
 		add_action( 'save_post', array( $this, 'update' ) );
@@ -112,6 +112,10 @@ final class PDEV_Plugin_Edit {
 	public function add_meta_boxes( $post_type ) {
 
 		remove_meta_box( 'postexcerpt', $post_type, 'normal' );
+
+
+		add_meta_box( 'pdev_details', esc_html__( 'Details', 'plugin-developer' ), array( $this, 'plugin_details_box' ), $post_type, 'normal', 'low' );
+		add_meta_box( 'pdev_stick', esc_html__( 'Sticky', 'plugin-developer' ), array( $this, 'submitbox_misc_actions' ), $post_type, 'side', 'low' );
 
 		add_meta_box( 'pdev_icon', esc_html__( 'Icon', 'plugin-developer' ), array( $this, 'icon_meta_box' ), $post_type, 'side', 'low' );
 	}

--- a/inc/core/post-types.php
+++ b/inc/core/post-types.php
@@ -140,6 +140,7 @@ function pdev_register_post_types() {
 		'map_meta_cap'        => true,
 		'capabilities'        => pdev_get_plugin_capabilities(),
 		'labels'              => pdev_get_plugin_labels(),
+		'show_in_rest'        => true,
 
 		// The rewrite handles the URL structure.
 		'rewrite' => array(


### PR DESCRIPTION
Since Block editor release, following and other related hooks / filters have been removed.

https://github.com/WordPress/gutenberg/issues/6757

**edit_form_after_editor**
**post_submitbox_misc_actions**

but plugin relies on these, so in Block Editor related content is not shown.

So I have done a quick / hot fix, so users can use it with Block Editor as well.

Fixes https://github.com/themehybrid/plugin-developer/issues/1

also on #slack channel another user requested same fix.

Did some quick testing and things seems to work fine, but you can do thorough testing if you like.